### PR TITLE
Fix use of <>built-like and <>all-built-like in examples

### DIFF
--- a/examples/monadic_define_1.clj
+++ b/examples/monadic_define_1.clj
@@ -23,7 +23,7 @@
 
 (def built-like (partial type/built-like type-repo))
 (def all-built-like (partial type/all-built-like type-repo))
-(def <>built-like (partial type/<>built-like type-repo))
-(def <>all-built-like (partial type/<>all-built-like type-repo))
+(def <>built-like #(type/<>built-like %1 type-repo %2))
+(def <>all-built-like #(type/<>all-built-like %1 type-repo %2))
 (def built-like? (partial type/built-like? type-repo))
 

--- a/examples/monadic_define_2.clj
+++ b/examples/monadic_define_2.clj
@@ -1,5 +1,5 @@
 (ns monadic-define-2
-  "Logging to Timbre"
+  "Using an Either monad to separate mistyped from valid values"
   (:require [structural-typing.type :as type]
             [structural-typing.preds :as preds]
             [structural-typing.assist.oopsie :as oopsie]
@@ -25,8 +25,8 @@
 
 (def built-like (partial type/built-like type-repo))
 (def all-built-like (partial type/all-built-like type-repo))
-(def <>built-like (partial type/<>built-like type-repo))
-(def <>all-built-like (partial type/<>all-built-like type-repo))
+(def <>built-like #(type/<>built-like %1 type-repo %2))
+(def <>all-built-like #(type/<>all-built-like %1 type-repo %2))
 (def built-like? (partial type/built-like? type-repo))
 
 

--- a/examples/timbre_define_1.clj
+++ b/examples/timbre_define_1.clj
@@ -20,8 +20,8 @@
 
 (def built-like (partial type/built-like type-repo))
 (def all-built-like (partial type/all-built-like type-repo))
-(def <>built-like (partial type/<>built-like type-repo))
-(def <>all-built-like (partial type/<>all-built-like type-repo))
+(def <>built-like #(type/<>built-like %1 type-repo %2))
+(def <>all-built-like #(type/<>all-built-like %1 type-repo %2))
 (def built-like? (partial type/built-like? type-repo))
 
 

--- a/examples/timbre_define_2.clj
+++ b/examples/timbre_define_2.clj
@@ -36,7 +36,7 @@
 
 (def built-like (partial type/built-like type-repo))
 (def all-built-like (partial type/all-built-like type-repo))
-(def <>built-like (partial type/<>built-like type-repo))
-(def <>all-built-like (partial type/<>all-built-like type-repo))
+(def <>built-like #(type/<>built-like %1 type-repo %2))
+(def <>all-built-like #(type/<>all-built-like %1 type-repo %2))
 (def built-like? (partial type/built-like? type-repo))
 


### PR DESCRIPTION
`<>built-like` and `<>all-built-like` take type-repo as the second argument, not the first one, so we can't use partial in this case, unfortunately.